### PR TITLE
build in install phase so output collapses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ before_install:
 
 install:
 - sudo apt-get -qq install git
+- bash build-onos.sh
 
 script:
-- bash build-onos.sh
 - sudo bash install-onos.sh
 - sudo bash test-onos.sh
 


### PR DESCRIPTION
Although it's a bit confusing, for our purposes we want to install in the test phase (because we're testing the installation script!) and build in the install phase (so that the voluminous build and test output gets compressed!)

Thanks to Brian for the suggestion.